### PR TITLE
support urls without a scheme

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,12 +47,21 @@ func main() {
 	seen := make(map[string]bool)
 
 	for sc.Scan() {
-		u, err := url.Parse(sc.Text())
+		text := sc.Text()
+
+	Urlparse:
+		u, err := url.Parse(text)
 		if err != nil {
 			if verbose {
 				fmt.Fprintf(os.Stderr, "parse failure: %s\n", err)
 			}
 			continue
+		}
+
+		// if the url provided doesn't have a parsed scheme, prepend http:// and parse again
+		if u.Scheme == "" {
+			text = "http://" + text
+			goto Urlparse
 		}
 
 		// some urlProc functions return multiple things,


### PR DESCRIPTION
This PR makes the app a bit more flexible to work around `url.Parse` requiring a scheme to fully parse everything (example: https://play.golang.org/p/wgXjqoP1C5B). Often I am working with input that may or may not have the scheme included.

I'm cool if you don't want to accept this PR since technically URLs should have a scheme. If that's the case a compromise may be to add a `--relaxed` flag to enable the functionality.

Example:
```
❯ cat /tmp/urls.txt 
sub.example.com/users?id=123&name=Sam
sub.example.com/orgs?org=ExCo#about
example.net/about#contact

❯ cat /tmp/urls.txt | unfurl domains
sub.example.com
sub.example.com
example.net

❯ echo "sub.example.com/users?id=123&name=Sam" | unfurl keys
name
id
```
