### PR TITLE
Changed domain parsing method to dramatially improve performance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/tomnomnom/unfurl
 
 go 1.18
 
-require github.com/jakewarren/tldomains v0.0.0-20220401175117-e21ec594add9
+require (
+	github.com/Cgboal/DomainParser v0.0.0-20210827145802-99068439e39f
+	github.com/jakewarren/tldomains v0.0.0-20220401175117-e21ec594add9
+)
 
 require golang.org/x/net v0.0.0-20220401154927-543a649e0bdd // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Cgboal/DomainParser v0.0.0-20210827145802-99068439e39f h1:M2XQFmJFYRW7om3/R3u1j+h97BGbMkRowFvfXJcyHPU=
+github.com/Cgboal/DomainParser v0.0.0-20210827145802-99068439e39f/go.mod h1:a0qCkWEjo4UooxH2Z1oU1kXc1wtyMIFYEpaLx8O5JyA=
 github.com/jakewarren/tldomains v0.0.0-20220401175117-e21ec594add9 h1:Pcr+CqSKD2lPGhHX/NU/md02EBwPR56X567WzO4iew0=
 github.com/jakewarren/tldomains v0.0.0-20220401175117-e21ec594add9/go.mod h1:iNGwlKkTjgCKgRtxW5G398eul77UVW1b4eLScbkEe+c=
 golang.org/x/net v0.0.0-20220401154927-543a649e0bdd h1:zYlwaUHTmxuf6H7hwO2dgwqozQmH7zf4x+/qql4oVWc=

--- a/main.go
+++ b/main.go
@@ -15,6 +15,10 @@ import (
 
 var extractor parser.Parser
 
+func init() {
+	extractor = parser.NewDomainParser()
+}
+
 func main() {
 
 	var unique bool
@@ -51,8 +55,6 @@ func main() {
 	sc := bufio.NewScanner(os.Stdin)
 
 	seen := make(map[string]bool)
-
-	extractor = parser.NewDomainParser()
 
 	for sc.Scan() {
 		u, err := parseURL(sc.Text())
@@ -298,9 +300,9 @@ func extractFromDomain(u *url.URL, selection string) string {
 
 	// remove the port before parsing
 	portRe := regexp.MustCompile(`(?m):\d+$`)
-	
+
 	domain := portRe.ReplaceAllString(u.Host, "")
-	
+
 	switch selection {
 	case "subdomain":
 		return extractor.GetSubdomain(domain)

--- a/main.go
+++ b/main.go
@@ -9,8 +9,10 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/jakewarren/tldomains"
+	"github.com/Cgboal/DomainParser"
 )
+
+var extractor parser.Parser
 
 func main() {
 
@@ -46,6 +48,8 @@ func main() {
 	sc := bufio.NewScanner(os.Stdin)
 
 	seen := make(map[string]bool)
+
+	extractor = parser.NewDomainParser()
 
 	for sc.Scan() {
 		u, err := parseURL(sc.Text())
@@ -275,28 +279,21 @@ func format(u *url.URL, f string) []string {
 
 func extractFromDomain(u *url.URL, selection string) string {
 
-	cache := os.TempDir() + "/tld.cache"
-	extract, err := tldomains.New(cache)
-
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed initialize tldomains: %s\n", err)
-	}
 	// remove the port before parsing
 	portRe := regexp.MustCompile(`(?m):\d+$`)
-
-	host := extract.Parse(portRe.ReplaceAllString(u.Host, ""))
-
+	
+	domain := portRe.ReplaceAllString(u.Host, "")
+	
 	switch selection {
 	case "subdomain":
-		return host.Subdomain
+		return extractor.GetSubdomain(domain)
 	case "root":
-		return host.Root
+		return extractor.GetDomain(domain)
 	case "tld":
-		return host.Suffix
+		return extractor.GetTld(domain)
 	default:
 		return ""
 	}
-
 }
 
 func init() {


### PR DESCRIPTION
I've changed unfurls domain parser to my own DomainParser package. Time to parse 1 million domains using `unfurl format "%r.%t" ` is reduced from 1m20s to 0.6s as a result. 