### PR TITLE
Make portRe constant

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,9 +15,11 @@ import (
 )
 
 var extractor parser.Parser
+var portRe *regexp.Regexp
 
 func init() {
-	extractor = parser.NewDomainParser()
+    portRe = regexp.MustCompile(`(?m):\d+$`)
+    extractor = parser.NewDomainParser()
 }
 
 func main() {
@@ -409,8 +411,6 @@ func format(u *url.URL, f string) []string {
 func extractFromDomain(u *url.URL, selection string) string {
 
 	// remove the port before parsing
-	portRe := regexp.MustCompile(`(?m):\d+$`)
-
 	domain := portRe.ReplaceAllString(u.Host, "")
 
 	switch selection {


### PR DESCRIPTION
When running `unfurl format %r.%t` on a long list of urls, the function `extractFromDomain()` will be called separately for each one of the urls, multiple times. 
This causes the same regex to be compiled multiple times:
```golang
	portRe := regexp.MustCompile(`(?m):\d+$`)
```

Instead, portRe should be a constant. I changed the regexp to be constant and tested it on a list of 1.1 Million urls. I got the following results:

```
Old: 0m35.384s
New: 0m21.374s
```